### PR TITLE
Feature: General tests for most tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+dist
 node_modules
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "tape test/*.spec.js"
+    "test": "tape test/*.spec.js | tap-spec"
   },
   "dependencies": {
     "browser-sync": "^2.9.11",
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.0",
+    "tap-spec": "^4.1.0",
     "tape": "^4.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.0",
+    "mkdirp": "^0.5.1",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "index.js",
     "lib"
   ],
+  "scripts": {
+    "test": "tape test/*.spec.js"
+  },
   "dependencies": {
     "browser-sync": "^2.9.11",
     "del": "^2.0.2",
@@ -24,5 +27,9 @@
     "postcss-import": "^7.0.0",
     "require-dir": "^0.3.0",
     "webpack": "^1.12.2"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.0",
+    "tape": "^4.2.1"
   }
 }

--- a/test/clean.spec.js
+++ b/test/clean.spec.js
@@ -1,15 +1,14 @@
 'use strict';
 
 var exec = require('child_process').exec;
-var fs = require('fs');
-var mkdirp = require('mkdirp');
 var tape = require('tape');
+var utils = require('./utils');
 
 tape('clean task', function (test) {
   test.plan(1);
-  mkdirp.sync('./test/dist/temp');
+  utils.makeDir('dist/temp');
   exec('gulp clean', { cwd: __dirname }, function () {
-    var files = fs.readdirSync('./test/dist');
+    var files = utils.readDir('dist');
     var isClean = files.every(function (filename) {
       return filename !== 'temp';
     });

--- a/test/clean.spec.js
+++ b/test/clean.spec.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var exec = require('child_process').exec;
+var fs = require('fs');
+var mkdirp = require('mkdirp');
+var tape = require('tape');
+
+tape('clean task', function (test) {
+  test.plan(1);
+  mkdirp.sync('./test/dist/temp');
+  exec('gulp clean', { cwd: __dirname }, function () {
+    var files = fs.readdirSync('./test/dist');
+    var isClean = files.every(function (filename) {
+      return filename !== 'temp';
+    });
+    test.ok(isClean, 'Cleans up files and folders');
+  });
+});

--- a/test/css.spec.js
+++ b/test/css.spec.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var exec = require('child_process').exec;
+var tape = require('tape');
+var utils = require('./utils');
+
+tape('css task', function (test) {
+  var expected = utils.getFixture('output.css');
+  test.plan(1);
+  exec('gulp css', { cwd: __dirname }, function () {
+    var actual = utils.getResult('input.css');
+    test.equal(expected, actual);
+  });
+});

--- a/test/css.spec.js
+++ b/test/css.spec.js
@@ -5,10 +5,10 @@ var tape = require('tape');
 var utils = require('./utils');
 
 tape('css task', function (test) {
-  var expected = utils.getFixture('output.css');
   test.plan(1);
   exec('gulp css', { cwd: __dirname }, function () {
-    var actual = utils.getResult('input.css');
+    var expected = utils.readFixture('output.css');
+    var actual = utils.readResult('input.css');
     test.equal(expected, actual, 'Processes CSS files');
   });
 });

--- a/test/css.spec.js
+++ b/test/css.spec.js
@@ -9,6 +9,6 @@ tape('css task', function (test) {
   test.plan(1);
   exec('gulp css', { cwd: __dirname }, function () {
     var actual = utils.getResult('input.css');
-    test.equal(expected, actual);
+    test.equal(expected, actual, 'Processes CSS files');
   });
 });

--- a/test/fixtures/input.css
+++ b/test/fixtures/input.css
@@ -1,0 +1,7 @@
+:root {
+  --result: "pass";
+}
+
+test {
+  result: var(--result);
+}

--- a/test/fixtures/input.hbs
+++ b/test/fixtures/input.hbs
@@ -1,0 +1,6 @@
+---
+layout: layout
+title: Title
+---
+{{title}}
+{{> partial}}

--- a/test/fixtures/input.js
+++ b/test/fixtures/input.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/test/fixtures/layout.hbs
+++ b/test/fixtures/layout.hbs
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+{{{content}}}

--- a/test/fixtures/output.css
+++ b/test/fixtures/output.css
@@ -1,0 +1,3 @@
+test {
+  result: "pass";
+}

--- a/test/fixtures/output.html
+++ b/test/fixtures/output.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+Title
+Partial

--- a/test/fixtures/partial.hbs
+++ b/test/fixtures/partial.hbs
@@ -1,0 +1,1 @@
+Partial

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -3,6 +3,10 @@
 var gulp = require('gulp');
 var tasks = require('../');
 
+tasks.clean(gulp, {
+  dest: './dist/temp'
+});
+
 tasks.css(gulp, {
   src: './fixtures/input.css',
   dest: './dist'

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -11,3 +11,14 @@ tasks.css(gulp, {
   src: './fixtures/input.css',
   dest: './dist'
 });
+
+tasks.html(gulp, {
+  dest: './dist',
+  layoutDir: './fixtures',
+  plugins: {
+    handlebars: {
+      batch: ['./fixtures'],
+    }
+  },
+  src: './fixtures/input.hbs'
+})

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var gulp = require('gulp');
+var tasks = require('../');
+
+tasks.css(gulp, {
+  src: './fixtures/input.css',
+  dest: './dist'
+});

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -21,4 +21,16 @@ tasks.html(gulp, {
     }
   },
   src: './fixtures/input.hbs'
-})
+});
+
+tasks.js(gulp, {
+  plugins: {
+    webpack: {
+      entry: './fixtures/input.js',
+      output: {
+        path: './dist',
+        filename: 'main.js'
+      }
+    }
+  }
+});

--- a/test/html.spec.js
+++ b/test/html.spec.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var exec = require('child_process').exec;
+var tape = require('tape');
+var utils = require('./utils');
+
+tape('html task', function (test) {
+  test.plan(1);
+  exec('gulp html', { cwd: __dirname }, function () {
+    var expected = utils.readFixture('output.html');
+    var actual = utils.readResult('input.html');
+    test.equal(expected, actual, 'Compiles Handlebars templates');
+  });
+});

--- a/test/js.spec.js
+++ b/test/js.spec.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var exec = require('child_process').exec;
+var tape = require('tape');
+var utils = require('./utils');
+
+tape('js task', function (test) {
+  test.plan(1);
+  exec('gulp js', { cwd: __dirname }, function () {
+    var result = utils.readResult('main.js');
+    var isTranspiled = result.indexOf('/******/') === 0;
+    test.ok(isTranspiled, 'Transpiles and resolves dependencies');
+  });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,7 +11,7 @@ function path () {
 }
 
 function readFile (filepath) {
-  return fs.readFileSync(filepath, 'utf8');
+  return fs.readFileSync(filepath, 'utf8').trim();
 }
 
 module.exports = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+module.exports = {
+  getFile: function (filepath) {
+    return fs.readFileSync(filepath, 'utf8');
+  },
+
+  getFixture: function (filename) {
+    return this.getFile(path.join('test/fixtures', filename));
+  },
+
+  getResult: function (filename) {
+    return this.getFile(path.join('test/dist', filename));
+  }
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,18 +1,33 @@
 'use strict';
 
 var fs = require('fs');
-var path = require('path');
+var mkdirp = require('mkdirp');
+var Path = require('path');
+
+function path () {
+  var segments = [].slice.call(arguments);
+  segments.unshift('./test');
+  return Path.join.apply(Path, segments);
+}
+
+function readFile (filepath) {
+  return fs.readFileSync(filepath, 'utf8');
+}
 
 module.exports = {
-  getFile: function (filepath) {
-    return fs.readFileSync(filepath, 'utf8');
+  makeDir: function (filepath) {
+    return mkdirp.sync(path(filepath));
   },
 
-  getFixture: function (filename) {
-    return this.getFile(path.join('test/fixtures', filename));
+  readDir: function (filepath) {
+    return fs.readdirSync(path(filepath));
   },
 
-  getResult: function (filename) {
-    return this.getFile(path.join('test/dist', filename));
+  readFixture: function (filename) {
+    return readFile(path('fixtures', filename));
+  },
+
+  readResult: function (filename) {
+    return readFile(path('dist', filename));
   }
 };


### PR DESCRIPTION
This adds some very general tests using [tape](https://github.com/substack/tape). Most of the tests simply compare the file contents of fixtures with the resulting files of each task. I'm not sure how to approach testing the `watch` and `serve` tasks yet.

#### Usage

```
npm test
```

![screen shot 2015-10-20 at 11 01 26 am](https://cloud.githubusercontent.com/assets/61204/10616433/fbf293ec-7719-11e5-831b-bba390341af6.png)