### PR TITLE
Feature: Include core helpers

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -5,6 +5,7 @@ var data = require('gulp-data');
 var frontMatter = require('front-matter');
 var fs = require('fs');
 var handlebars = require('gulp-compile-handlebars');
+var helpers = require('core-hbs-helpers');
 var path = require('path');
 var rename = require('gulp-rename');
 
@@ -14,8 +15,9 @@ var defaults = {
   layoutDir: './src/layouts',
   plugins: {
     handlebars: {
-      ignorePartials: true,
       batch: ['./src/partials'],
+      helpers: helpers,
+      ignorePartials: true
     }
   },
   src: './src/*.hbs',

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "browser-sync": "^2.9.11",
+    "core-hbs-helpers": "git://github.com/cloudfour/core-hbs-helpers.git",
     "del": "^2.0.2",
     "front-matter": "^1.0.0",
     "gulp-compile-handlebars": "^0.5.0",

--- a/test/fixtures/input.hbs
+++ b/test/fixtures/input.hbs
@@ -3,4 +3,5 @@ layout: layout
 title: Title
 ---
 {{title}}
+{{slug title}}
 {{> partial}}

--- a/test/fixtures/output.html
+++ b/test/fixtures/output.html
@@ -1,3 +1,4 @@
 <!DOCTYPE html>
 Title
+title
 Partial


### PR DESCRIPTION
This updates the `html` task default options and associated tests to acknowledge the `core-hbs-helpers` package.

Pertains to #10 