### PR TITLE
Fix: Task default option merging

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var defaultsDeep = require('lodash').defaultsDeep;
+var merge = require('lodash').merge;
 var gulpif = require('gulp-if');
 var imagemin = require('gulp-imagemin');
 
@@ -13,7 +13,7 @@ var defaults = {
 };
 
 module.exports = function (gulp, options) {
-  var opts = defaultsDeep(options, defaults);
+  var opts = merge({}, defaults, options);
   var dest = opts.dest;
   var optimize = opts.optimize;
   var plugins = opts.plugins;

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var defaultsDeep = require('lodash').defaultsDeep;
+var merge = require('lodash').merge;
 var del = require('del');
 
 var defaults = {
@@ -8,7 +8,7 @@ var defaults = {
 };
 
 module.exports = function (gulp, options) {
-  var opts = defaultsDeep(options, defaults);
+  var opts = merge({}, defaults, options);
   var dest = opts.dest;
 
   gulp.task('clean', function (done) {

--- a/lib/css.js
+++ b/lib/css.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var defaultsDeep = require('lodash').defaultsDeep;
+var merge = require('lodash').merge;
 var cssnano = require('gulp-cssnano');
 var cssnext = require('postcss-cssnext');
 var gulpif = require('gulp-if');
@@ -14,7 +14,7 @@ var defaults = {
 };
 
 module.exports = function (gulp, options) {
-  var opts = defaultsDeep(options, defaults);
+  var opts = merge({}, defaults, options);
   var dest = opts.dest;
   var optimize = opts.optimize;
   var src = opts.src;

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var defaultsDeep = require('lodash').defaultsDeep;
+var merge = require('lodash').merge;
 var data = require('gulp-data');
 var frontMatter = require('front-matter');
 var fs = require('fs');
@@ -23,7 +23,7 @@ var defaults = {
 };
 
 module.exports = function (gulp, options) {
-  var opts = defaultsDeep(options, defaults);
+  var opts = merge({}, defaults, options);
   var sharedData = opts.sharedData;
   var dest = opts.dest;
   var layoutDir = opts.layoutDir;

--- a/lib/js.js
+++ b/lib/js.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var defaultsDeep = require('lodash').defaultsDeep;
+var merge = require('lodash').merge;
 var utils = require('gulp-util');
 var webpack = require('webpack');
 var PluginError = utils.PluginError;
@@ -20,7 +20,7 @@ var defaults = {
 };
 
 module.exports = function (gulp, options) {
-  var opts = defaultsDeep(options, defaults);
+  var opts = merge({}, defaults, options);
   var plugins = opts.plugins;
   var optimize = opts.optimize;
 

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var defaultsDeep = require('lodash').defaultsDeep;
+var merge = require('lodash').merge;
 var browserSync = require('browser-sync').create();
 
 var defaults = {
@@ -13,7 +13,7 @@ var defaults = {
 };
 
 module.exports = function (gulp, options) {
-  var opts = defaultsDeep(options, defaults);
+  var opts = merge({}, defaults, options);
   var plugins = opts.plugins;
 
   gulp.task('serve', function () {

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var defaultsDeep = require('lodash').defaultsDeep;
+var merge = require('lodash').merge;
 
 var defaults = {
   watchers: [
@@ -12,7 +12,7 @@ var defaults = {
 };
 
 module.exports = function (gulp, options) {
-  var opts = defaultsDeep(options, defaults);
+  var opts = merge({}, defaults, options);
   var watchers = opts.watchers;
 
   gulp.task('watch', function () {


### PR DESCRIPTION
Closes #16 

This replaces `_.defaultsDeep` with `_.merge` for combining task option defaults with argument-supplied ones. The prior merging function was resulting in unexpected behavior with deeply nested defaults.