### PR TITLE
Convert `html` task to ES2015

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "ecmaFeatures": {
+    "modules": true
+  },
+  "env": {
+    "es6": true,
+    "node": true
+  }
+}

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,14 +1,14 @@
 'use strict';
 
-let merge = require('lodash').merge;
-let data = require('gulp-data');
-let frontMatter = require('front-matter');
-let fs = require('fs');
-let handlebars = require('gulp-compile-handlebars');
-let path = require('path');
-let rename = require('gulp-rename');
+var merge = require('lodash').merge;
+var data = require('gulp-data');
+var frontMatter = require('front-matter');
+var fs = require('fs');
+var handlebars = require('gulp-compile-handlebars');
+var path = require('path');
+var rename = require('gulp-rename');
 
-let defaults = {
+var defaults = {
   sharedData: {},
   dest: './dist',
   layoutDir: './src/layouts',
@@ -23,8 +23,8 @@ let defaults = {
 };
 
 module.exports = function(gulp, options) {
-  let opts = merge({}, defaults, options);
-  let { sharedData, dest, layoutDir, plugins, src, templateExt } = opts;
+  var opts = merge({}, defaults, options);
+  var { sharedData, dest, layoutDir, plugins, src, templateExt } = opts;
 
   /* Helper to extract meta data embedded in the file contents. */
   function parseContent (file) {
@@ -42,21 +42,21 @@ module.exports = function(gulp, options) {
 
   gulp.task('html', function () {
     /* Helper to abstract handlebars sub-task. */
-    let compileHtml = function () {
+    var compileHtml = function () {
       return handlebars(sharedData, plugins.handlebars);
     };
 
     /* Helper to abstract FrontMatter sub-task. */
-    let parseData = function (file) {
-      let content = parseContent(file);
+    var parseData = function (file) {
+      var content = parseContent(file);
       file.contents = new Buffer(content.body);
       return content.attributes;
     };
 
     /* Helper to abstract template replacement sub-task. */
-    let wrapHtml = function (file, name) {
-      var html = String(file.contents);
-      var path = getLayoutPath(name);
+    var wrapHtml = function (file, name) {
+      var html = String(file.contents),
+        path = getLayoutPath(name);
 
       file.contents = fs.readFileSync(path);
       return { content: html };

--- a/lib/html.js
+++ b/lib/html.js
@@ -22,12 +22,7 @@ let defaults = {
 
 module.exports = function(gulp, options) {
   let opts = merge({}, defaults, options);
-  let sharedData = opts.sharedData;
-  let dest = opts.dest;
-  let layoutDir = opts.layoutDir;
-  let plugins = opts.plugins;
-  let src = opts.src;
-  let templateExt = opts.templateExt;
+  let { sharedData, dest, layoutDir, plugins, src, templateExt } = opts;
 
   /* Helper to extract meta data embedded in the file contents. */
   function parseContent (file) {

--- a/lib/html.js
+++ b/lib/html.js
@@ -41,12 +41,12 @@ module.exports = function(gulp, options) {
   gulp.task('html', function () {
     /* Helper to abstract handlebars sub-task. */
     let compileHtml = function () {
-      return handlebars(sharedData, plugins.handlebars)
+      return handlebars(sharedData, plugins.handlebars);
     };
 
     /* Helper to abstract FrontMatter sub-task. */
     let parseData = function (file) {
-      var content = parseContent(file);
+      let content = parseContent(file);
       file.contents = new Buffer(content.body);
       return content.attributes;
     };
@@ -61,18 +61,11 @@ module.exports = function(gulp, options) {
     }
 
     return gulp.src(src)
-      .pipe(data(function (file) {
-        return parseData(file);
-      }))
+      .pipe(data((file) => parseData(file)))
       .pipe(compileHtml())
-      .pipe(data(function (file) {
-        let layoutName = file.data.layout;
-        return wrapHtml(file, layoutName);
-      }))
+      .pipe(data((file) => wrapHtml(file, file.data.layout)))
       .pipe(compileHtml())
-      .pipe(rename(function (path) {
-        path.extname = '.html'
-      }))
+      .pipe(rename((path) => path.extname = '.html'))
       .pipe(gulp.dest(dest));
   });
 };

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,12 +1,12 @@
-var merge = require('lodash').merge;
-var data = require('gulp-data');
-var frontMatter = require('front-matter');
-var fs = require('fs');
-var handlebars = require('gulp-compile-handlebars');
-var path = require('path');
-var rename = require('gulp-rename');
+let merge = require('lodash').merge;
+let data = require('gulp-data');
+let frontMatter = require('front-matter');
+let fs = require('fs');
+let handlebars = require('gulp-compile-handlebars');
+let path = require('path');
+let rename = require('gulp-rename');
 
-var defaults = {
+let defaults = {
   sharedData: {},
   dest: './dist',
   layoutDir: './src/layouts',
@@ -20,14 +20,14 @@ var defaults = {
   templateExt: 'hbs'
 };
 
-module.exports = function (gulp, options) {
-  var opts = merge({}, defaults, options);
-  var sharedData = opts.sharedData;
-  var dest = opts.dest;
-  var layoutDir = opts.layoutDir;
-  var plugins = opts.plugins;
-  var src = opts.src;
-  var templateExt = opts.templateExt;
+module.exports = function(gulp, options) {
+  let opts = merge({}, defaults, options);
+  let sharedData = opts.sharedData;
+  let dest = opts.dest;
+  let layoutDir = opts.layoutDir;
+  let plugins = opts.plugins;
+  let src = opts.src;
+  let templateExt = opts.templateExt;
 
   /* Helper to extract meta data embedded in the file contents. */
   function parseContent (file) {
@@ -45,19 +45,19 @@ module.exports = function (gulp, options) {
 
   gulp.task('html', function () {
     /* Helper to abstract handlebars sub-task. */
-    var compileHtml = function () {
+    let compileHtml = function () {
       return handlebars(sharedData, plugins.handlebars)
     };
 
     /* Helper to abstract FrontMatter sub-task. */
-    var parseData = function (file) {
+    let parseData = function (file) {
       var content = parseContent(file);
       file.contents = new Buffer(content.body);
       return content.attributes;
     };
 
     /* Helper to abstract template replacement sub-task. */
-    var wrapHtml = function (file, name) {
+    let wrapHtml = function (file, name) {
       var html = String(file.contents);
       var path = getLayoutPath(name);
 
@@ -71,7 +71,7 @@ module.exports = function (gulp, options) {
       }))
       .pipe(compileHtml())
       .pipe(data(function (file) {
-        var layoutName = file.data.layout;
+        let layoutName = file.data.layout;
         return wrapHtml(file, layoutName);
       }))
       .pipe(compileHtml())

--- a/lib/html.js
+++ b/lib/html.js
@@ -33,8 +33,8 @@ module.exports = function(gulp, options) {
   function getLayoutPath (name) {
     return path.resolve(
       process.cwd(),
-      layoutDir + '/',
-      name + '.' + templateExt
+      `${layoutDir}/`,
+      `${name}.${templateExt}`
     );
   }
 

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var merge = require('lodash').merge;
 var data = require('gulp-data');
 var frontMatter = require('front-matter');

--- a/lib/html.js
+++ b/lib/html.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let merge = require('lodash').merge;
 let data = require('gulp-data');
 let frontMatter = require('front-matter');


### PR DESCRIPTION
Fixes #21 

I opted to leave module stuff (import/export) alone until we have all of this in place, as we were running into some fun with `requireDir`.

Also adds `.eslintrc`, if that's OK.

/cc @mrgerardorodriguez 