### PR TITLE
Patch object destructuring

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -23,8 +23,15 @@ var defaults = {
 };
 
 module.exports = function(gulp, options) {
-  var opts = merge({}, defaults, options);
-  var { sharedData, dest, layoutDir, plugins, src, templateExt } = opts;
+  var opts = merge({}, defaults, options),
+    sharedData  = opts.sharedData,
+    dest        = opts.dest,
+    layoutDir   = opts.layoutDir,
+    plugins     = opts.plugins,
+    src         = opts.src,
+    templateExt = opts.templateExt;
+  // Object destructuring is being difficult right now
+  // var { sharedData, dest, layoutDir, plugins, src, templateExt } = opts;
 
   /* Helper to extract meta data embedded in the file contents. */
   function parseContent (file) {


### PR DESCRIPTION
We don't understand why yet, but object destructuring
is choking when gulp tasks are run in certain contexts
(and yet tests pass...hmmm wut?) so for now I'm reverting
back to ES5-style var declarations in the html task.