### PR TITLE
Feature: Add optional class prefixing with `prefix` option

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -6,10 +6,12 @@ var cssnext = require('postcss-cssnext');
 var gulpif = require('gulp-if');
 var importer = require('postcss-import');
 var postcss = require('gulp-postcss');
+var prefixer = require('postcss-class-prefix');
 
 var defaults = {
   dest: './dist',
   optimize: false,
+  prefix: false,
   src: './src/main.css'
 };
 
@@ -17,13 +19,23 @@ module.exports = function (gulp, options) {
   var opts = merge({}, defaults, options);
   var dest = opts.dest;
   var optimize = opts.optimize;
+  var prefix = opts.prefix;
+  // Don't prefix classes formatted as components or utilities.
+  var prefixOpts = {ignore: [/^[^A-Zu-]/]};
   var src = opts.src;
+  var plugins = [
+    importer(),
+    cssnext()
+  ];
+
+  if (prefix) {
+    plugins.push(
+      prefixer(prefix, prefixOpts)
+    )
+  }
 
   gulp.task('css', () => gulp.src(src)
-    .pipe(postcss([
-      importer(),
-      cssnext()
-    ]))
+    .pipe(postcss(plugins))
     .pipe(gulpif(optimize, cssnano()))
     .pipe(gulp.dest(dest)));
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.6",
     "lodash": "^3.10.1",
+    "postcss-class-prefix": "^0.3.0",
     "postcss-cssnext": "^2.1.0",
     "postcss-import": "^7.0.0",
     "require-dir": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-gulp-tasks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Core reusable gulp tasks for Cloud Four projects",
   "main": "index.js",
   "repository": {

--- a/test/fixtures/input.css
+++ b/test/fixtures/input.css
@@ -5,3 +5,15 @@
 test {
   result: var(--result);
 }
+
+.test {
+  result: "not prefixed";
+}
+
+.u-test {
+  result: "prefixed";
+}
+
+.Test {
+  result: "prefixed";
+}

--- a/test/fixtures/output.css
+++ b/test/fixtures/output.css
@@ -1,3 +1,15 @@
 test {
   result: "pass";
 }
+
+.test {
+  result: "not prefixed";
+}
+
+.prefix-u-test {
+  result: "prefixed";
+}
+
+.prefix-Test {
+  result: "prefixed";
+}

--- a/test/gulpfile.js
+++ b/test/gulpfile.js
@@ -14,7 +14,8 @@ tasks.clean(gulp, {
 
 tasks.css(gulp, {
   src: './fixtures/input.css',
-  dest: './dist'
+  dest: './dist',
+  prefix: 'prefix-'
 });
 
 tasks.html(gulp, {


### PR DESCRIPTION
This adds the ability to use https://github.com/thompsongl/postcss-class-prefix by supplying a `prefix` option to the task:

```js
var defaults = {
  dest: './dist',
  optimize: false,
  prefix: false,    // <-- e.g. "drizzle-"
  src: './src/main.css'
};
```

/CC @mrgerardorodriguez 