### PR TITLE
Add option to rename tasks

### DIFF
--- a/lib/assets.js
+++ b/lib/assets.js
@@ -7,6 +7,7 @@ var imagemin = require('gulp-imagemin');
 var defaults = {
   src: './assets/*',
   dest: './dist/',
+  name: 'assets',
   plugins: {
     imagemin: { optimizationLevel: 0 }
   }
@@ -18,8 +19,9 @@ module.exports = function (gulp, options) {
   var optimize = opts.optimize;
   var plugins = opts.plugins;
   var src = opts.src;
+  var name = opts.name;
 
-  gulp.task('assets', () => gulp.src(src)
+  gulp.task(name, () => gulp.src(src)
     .pipe(gulpif(optimize, imagemin(plugins.imagemin)))
     .pipe(gulp.dest(dest)));
 };

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -4,12 +4,14 @@ var merge = require('lodash').merge;
 var del = require('del');
 
 var defaults = {
-  dest: 'dist'
+  dest: 'dist',
+  name: 'clean'
 };
 
 module.exports = function (gulp, options) {
   var opts = merge({}, defaults, options);
   var dest = opts.dest;
+  var name = opts.name;
 
-  gulp.task('clean', () => del(dest));
+  gulp.task(name, () => del(dest));
 };

--- a/lib/css.js
+++ b/lib/css.js
@@ -11,6 +11,7 @@ var prefixer = require('postcss-class-prefix');
 var defaults = {
   dest: './dist',
   optimize: false,
+  name: 'css',
   prefix: false,
   src: './src/main.css'
 };
@@ -19,6 +20,7 @@ module.exports = function (gulp, options) {
   var opts = merge({}, defaults, options);
   var dest = opts.dest;
   var optimize = opts.optimize;
+  var name = opts.name;
   var prefix = opts.prefix;
   // Don't prefix classes formatted as components or utilities.
   var prefixOpts = {ignore: [/^[^A-Zu-]/]};
@@ -34,7 +36,7 @@ module.exports = function (gulp, options) {
     )
   }
 
-  gulp.task('css', () => gulp.src(src)
+  gulp.task(name, () => gulp.src(src)
     .pipe(postcss(plugins))
     .pipe(gulpif(optimize, cssnano()))
     .pipe(gulp.dest(dest)));

--- a/lib/html.js
+++ b/lib/html.js
@@ -12,6 +12,7 @@ var defaults = {
   sharedData: {},
   dest: './dist',
   layoutDir: './src/layouts',
+  name: 'html',
   plugins: {
     handlebars: {
       ignorePartials: true,
@@ -27,6 +28,7 @@ module.exports = function(gulp, options) {
     sharedData  = opts.sharedData,
     dest        = opts.dest,
     layoutDir   = opts.layoutDir,
+    name        = opts.name,
     plugins     = opts.plugins,
     src         = opts.src,
     templateExt = opts.templateExt;
@@ -47,7 +49,7 @@ module.exports = function(gulp, options) {
     );
   }
 
-  gulp.task('html', function () {
+  gulp.task(name, function () {
     /* Helper to abstract handlebars sub-task. */
     var compileHtml = function () {
       return handlebars(sharedData, plugins.handlebars);

--- a/lib/js.js
+++ b/lib/js.js
@@ -6,6 +6,7 @@ var webpack = require('webpack');
 var PluginError = utils.PluginError;
 
 var defaults = {
+  name: 'js',
   optimize: false,
   plugins: {
     webpack: {
@@ -21,10 +22,11 @@ var defaults = {
 
 module.exports = function (gulp, options) {
   var opts = merge({}, defaults, options);
+  var name = opts.name;
   var plugins = opts.plugins;
   var optimize = opts.optimize;
 
-  gulp.task('js', function (done) {
+  gulp.task(name, function (done) {
     var settings = plugins.webpack;
 
     if (optimize) {

--- a/lib/serve.js
+++ b/lib/serve.js
@@ -4,6 +4,7 @@ var merge = require('lodash').merge;
 var browserSync = require('browser-sync').create();
 
 var defaults = {
+  name: 'serve',
   plugins: {
     browserSync: {
       files: ['**/*'],
@@ -15,8 +16,9 @@ var defaults = {
 module.exports = function (gulp, options) {
   var opts = merge({}, defaults, options);
   var plugins = opts.plugins;
+  var name = opts.name;
 
-  gulp.task('serve', function () {
+  gulp.task(name, function () {
     browserSync.init(plugins.browserSync);
   });
 };

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -3,6 +3,7 @@
 var merge = require('lodash').merge;
 
 var defaults = {
+  name: 'watch',
   watchers: [
     {
       match: ['src/**/*.css'],
@@ -14,8 +15,9 @@ var defaults = {
 module.exports = function (gulp, options) {
   var opts = merge({}, defaults, options);
   var watchers = opts.watchers;
+  var name = opts.name;
 
-  gulp.task('watch', function () {
+  gulp.task(name, function () {
     watchers.forEach(function (item) {
       gulp.watch(item.match, item.tasks);
     });


### PR DESCRIPTION
This allows the same task to be registered multiple times (with a different name) in the same Gulpfile. This allows the tasks to be used with different options per input stream.

/CC @tylersticka @lyzadanger 