### PR TITLE
Feature: Add support for postcss-use

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -7,6 +7,7 @@ var gulpif = require('gulp-if');
 var importer = require('postcss-import');
 var postcss = require('gulp-postcss');
 var prefixer = require('postcss-class-prefix');
+var use = require('postcss-use');
 
 var defaults = {
   dest: './dist',
@@ -27,6 +28,7 @@ module.exports = function (gulp, options) {
   var src = opts.src;
   var plugins = [
     importer(),
+    use({modules: '*'}),
     cssnext()
   ];
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "mkdirp": "^0.5.1",
+    "postcss-class-prefix": "^0.3.0",
+    "postcss-discard-comments": "^2.0.4",
+    "postcss-discard-empty": "^2.0.1",
+    "postcss-mixins": "^4.0.1",
+    "postcss-use": "^2.0.2",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.1"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postcss-class-prefix": "^0.3.0",
     "postcss-cssnext": "^2.1.0",
     "postcss-import": "^7.0.0",
+    "postcss-use": "^2.0.2",
     "require-dir": "^0.3.0",
     "webpack": "^1.12.2"
   },
@@ -44,7 +45,6 @@
     "postcss-discard-comments": "^2.0.4",
     "postcss-discard-empty": "^2.0.1",
     "postcss-mixins": "^4.0.1",
-    "postcss-use": "^2.0.2",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.1"
   }

--- a/test/fixtures/input.css
+++ b/test/fixtures/input.css
@@ -1,4 +1,9 @@
+@use postcss-mixins;
+@use postcss-discard-comments(removeAll: true);
+@use postcss-discard-empty;
+
 :root {
+  /* This comment should be removed */
   --result: "pass";
 }
 
@@ -16,4 +21,17 @@ test {
 
 .Test {
   result: "prefixed";
+}
+
+should-not-appear {}
+
+@define-mixin foo {
+  foo {
+    bar: baz;
+    @mixin-content;
+  }
+}
+
+@mixin foo {
+  bang: biz;
 }

--- a/test/fixtures/output.css
+++ b/test/fixtures/output.css
@@ -1,15 +1,20 @@
-test {
-  result: "pass";
+test{
+  result:"pass";
 }
 
-.test {
-  result: "not prefixed";
+.test{
+  result:"not prefixed";
 }
 
-.prefix-u-test {
-  result: "prefixed";
+.prefix-u-test{
+  result:"prefixed";
 }
 
-.prefix-Test {
-  result: "prefixed";
+.prefix-Test{
+  result:"prefixed";
+}
+
+foo{
+  bar:baz;
+  bang:biz;
 }


### PR DESCRIPTION
Re: #40 

This allows the use of `@use`.

This was originally intended to replace the need to also include `postcss-class-prefix`, but unfortunately that plugin needs a string argument in addition to an options hash (which doesn't seem to work with `postcss-use`).

/CC @mrgerardorodriguez 