### PR TITLE
Feat: Simplify CSS plugin usage

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -2,7 +2,6 @@
 
 var merge = require('lodash').merge;
 var cssnano = require('gulp-cssnano');
-var cssnext = require('postcss-cssnext');
 var gulpif = require('gulp-if');
 var importer = require('postcss-import');
 var postcss = require('gulp-postcss');
@@ -28,8 +27,7 @@ module.exports = function (gulp, options) {
   var src = opts.src;
   var plugins = [
     importer(),
-    use({modules: '*'}),
-    cssnext()
+    use({modules: '*'})
   ];
 
   if (prefix) {

--- a/lib/css.js
+++ b/lib/css.js
@@ -22,8 +22,13 @@ module.exports = function (gulp, options) {
   var optimize = opts.optimize;
   var name = opts.name;
   var prefix = opts.prefix;
-  // Don't prefix classes formatted as components or utilities.
-  var prefixOpts = {ignore: [/^[^A-Zu-]/]};
+  // Don't prefix classes formatted as components, utilities or states.
+  var prefixOpts = {
+    ignore: [
+      /^[^A-Zu-]/,
+      /^(is|has)-/
+    ]
+  };
   var src = opts.src;
   var plugins = [
     importer(),

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "gulp-util": "^3.0.6",
     "lodash": "^3.10.1",
     "postcss-class-prefix": "^0.3.0",
-    "postcss-cssnext": "^2.1.0",
     "postcss-import": "^7.0.0",
     "postcss-use": "^2.0.2",
     "require-dir": "^0.3.0",
@@ -41,6 +40,7 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "mkdirp": "^0.5.1",
+    "postcss-cssnext": "^2.1.0",
     "postcss-class-prefix": "^0.3.0",
     "postcss-discard-comments": "^2.0.4",
     "postcss-discard-empty": "^2.0.1",

--- a/test/fixtures/input.css
+++ b/test/fixtures/input.css
@@ -16,6 +16,14 @@ test {
   result: "not prefixed";
 }
 
+.is-test {
+  result: "not prefixed";
+}
+
+.has-test {
+  result: "not prefixed";
+}
+
 .u-test {
   result: "prefixed";
 }

--- a/test/fixtures/input.css
+++ b/test/fixtures/input.css
@@ -1,4 +1,5 @@
 @use postcss-mixins;
+@use postcss-cssnext;
 @use postcss-discard-comments(removeAll: true);
 @use postcss-discard-empty;
 

--- a/test/fixtures/output.css
+++ b/test/fixtures/output.css
@@ -6,6 +6,14 @@ test{
   result:"not prefixed";
 }
 
+.is-test{
+  result:"not prefixed";
+}
+
+.has-test{
+  result:"not prefixed";
+}
+
 .prefix-u-test{
   result:"prefixed";
 }


### PR DESCRIPTION
Re: #41 

This removes `postcss-cssnext` altogether from the predefined plugins. From here on, we'll use `@use` in our project CSS files to supply any needed PostCSS plugins (except for `postcss-import` and `postcss-class-prefix`, which doesn't work with `@use`).

This will allow more flexibility around which plugins should be used, their associated options, and the order in which they're applied.

/CC @tylersticka 