### PR TITLE
Watch newly created files

### DIFF
--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var watch = require('gulp-watch');
+var runSequence = require('run-sequence');
 var merge = require('lodash').merge;
 
 var defaults = {
@@ -19,7 +21,9 @@ module.exports = function (gulp, options) {
 
   gulp.task(name, function () {
     watchers.forEach(function (item) {
-      gulp.watch(item.match, item.tasks);
+      watch(item.match, function () {
+        runSequence(item.tasks);
+      });
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
     "gulp-postcss": "^6.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.6",
+    "gulp-watch": "^4.3.11",
     "lodash": "^3.10.1",
     "postcss-class-prefix": "^0.3.0",
     "postcss-import": "^7.0.0",
     "postcss-use": "^2.0.2",
     "require-dir": "^0.3.0",
+    "run-sequence": "^1.2.2",
     "webpack": "^1.12.2"
   },
   "devDependencies": {


### PR DESCRIPTION
In a perfect world, we could simply run:

```js
gulp.watch(item.match, item.tasks);
```

Unfortunately, this does not appear to watch new files without restarting the task. So we're using a plugin that does. Which means in order to retain this functionality, we also need something that replaces the way `gulp.run` or `gulp.start` used to work (as neither are still supported).

Hopefully we can simplify again when/if Gulp 4 is released.

There isn't an existing test for the "watch" task, and I am apparently not smart enough to create one from the existing examples (which mostly deal with simple inputs and outputs). I tested this locally by appending the following to `test/gulpfile.js`:

```js
tasks.watch(gulp, {
  watchers: [
    {
      match: ['./fixtures/input.css', './fixtures/new.css'],
      tasks: ['css']
    }
  ]
});
```

Then I ran `gulp watch`, created a `new.css` file in the appropriate directory, and observed that the task picked up the new file correctly.