### PR TITLE
Stop css and html watch errors from killing task

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -4,6 +4,7 @@ var merge = require('lodash').merge;
 var cssnano = require('gulp-cssnano');
 var gulpif = require('gulp-if');
 var plumber = require('gulp-plumber');
+var gutil = require('gulp-util');
 var importer = require('postcss-import');
 var postcss = require('gulp-postcss');
 var prefixer = require('postcss-class-prefix');
@@ -17,6 +18,21 @@ var defaults = {
   plumb: true,
   src: './src/main.css'
 };
+
+/**
+ * Hack for PostCSS error recovery.
+ *
+ * @see https://github.com/floatdrop/gulp-plumber/issues/30#issuecomment-191889730
+ */
+function plumberHack (done) {
+  return {
+    errorHandler: error => {
+      error.showStack = false;
+      gutil.log(error.toString());
+      done();
+    }
+  }
+}
 
 module.exports = function (gulp, options) {
   var opts = merge({}, defaults, options);
@@ -44,8 +60,8 @@ module.exports = function (gulp, options) {
     )
   }
 
-  gulp.task(name, () => gulp.src(src)
-    .pipe(gulpif(plumb, plumber()))
+  gulp.task(name, done => gulp.src(src)
+    .pipe(gulpif(plumb, plumber(plumberHack(done))))
     .pipe(postcss(plugins))
     .pipe(gulpif(optimize, cssnano()))
     .pipe(gulp.dest(dest)));

--- a/lib/css.js
+++ b/lib/css.js
@@ -3,6 +3,7 @@
 var merge = require('lodash').merge;
 var cssnano = require('gulp-cssnano');
 var gulpif = require('gulp-if');
+var plumber = require('gulp-plumber');
 var importer = require('postcss-import');
 var postcss = require('gulp-postcss');
 var prefixer = require('postcss-class-prefix');
@@ -13,6 +14,7 @@ var defaults = {
   optimize: false,
   name: 'css',
   prefix: false,
+  plumb: true,
   src: './src/main.css'
 };
 
@@ -22,6 +24,7 @@ module.exports = function (gulp, options) {
   var optimize = opts.optimize;
   var name = opts.name;
   var prefix = opts.prefix;
+  var plumb = opts.plumb;
   // Don't prefix classes formatted as components, utilities or states.
   var prefixOpts = {
     ignore: [
@@ -42,6 +45,7 @@ module.exports = function (gulp, options) {
   }
 
   gulp.task(name, () => gulp.src(src)
+    .pipe(gulpif(plumb, plumber()))
     .pipe(postcss(plugins))
     .pipe(gulpif(optimize, cssnano()))
     .pipe(gulp.dest(dest)));

--- a/lib/html.js
+++ b/lib/html.js
@@ -2,6 +2,8 @@
 
 var merge = require('lodash').merge;
 var data = require('gulp-data');
+var gulpif = require('gulp-if');
+var plumber = require('gulp-plumber');
 var frontMatter = require('front-matter');
 var fs = require('fs');
 var handlebars = require('gulp-compile-handlebars');
@@ -20,7 +22,8 @@ var defaults = {
     }
   },
   src: './src/*.hbs',
-  templateExt: 'hbs'
+  templateExt: 'hbs',
+  plumb: true
 };
 
 module.exports = function(gulp, options) {
@@ -31,7 +34,8 @@ module.exports = function(gulp, options) {
     name        = opts.name,
     plugins     = opts.plugins,
     src         = opts.src,
-    templateExt = opts.templateExt;
+    templateExt = opts.templateExt,
+    plumb       = opts.plumb;
   // Object destructuring is being difficult right now
   // var { sharedData, dest, layoutDir, plugins, src, templateExt } = opts;
 
@@ -72,6 +76,7 @@ module.exports = function(gulp, options) {
     }
 
     return gulp.src(src)
+      .pipe(gulpif(plumb, plumber()))
       .pipe(data((file) => parseData(file)))
       .pipe(compileHtml())
       .pipe(data((file) => wrapHtml(file, file.data.layout)))

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-cssnano": "^2.0.0",
     "gulp-data": "^1.2.0",
     "gulp-if": "^2.0.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.0.1",
     "gulp-rename": "^1.2.2",
     "gulp-util": "^3.0.6",


### PR DESCRIPTION
This PR uses [`gulp-plumber`](https://github.com/floatdrop/gulp-plumber) to avoid killing the `watch` task entirely when there are errors (such as typos) in the `html` and `css` tasks.

The implementation is straightforward for the `html` task... the desired behavior was achieved by default, and Handlebars' characteristically mindless error messages offer few opportunities for rich customization.

For the`css` task, some modest hackery was used to accomplish two things:

- To overcome an issue where the `watch` task continues but the original task never resolves (see code comments).
- To decrease the verbosity of PostCSS errors. While this is useful for plugin developers, it's just noise for us in development to see every `ValueParser.walk` error in the plugin stack.

The `js` task was not altered because it already has comparatively robust error handling. You need to do a _lot_ to break it.

Screenshots of this work in action, showing an error that would have previously required a restart resuming automatically once the offending code has been fixed:

![screen shot 2016-11-22 at 12 12 54 pm](https://cloud.githubusercontent.com/assets/69633/20541968/4d7fcdea-b0b4-11e6-9f41-9e20d4974be2.png)
![screen shot 2016-11-22 at 12 57 02 pm](https://cloud.githubusercontent.com/assets/69633/20541967/4d7a8e66-b0b4-11e6-8e80-52cd05889cc2.png)

