### PR TITLE
Support CSS linting using stylelint

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -9,6 +9,8 @@ var importer = require('postcss-import');
 var postcss = require('gulp-postcss');
 var prefixer = require('postcss-class-prefix');
 var use = require('postcss-use');
+var stylelint = require('stylelint');
+var reporter = require('postcss-reporter');
 
 var defaults = {
   dest: './dist',
@@ -16,6 +18,7 @@ var defaults = {
   name: 'css',
   prefix: false,
   plumb: true,
+  lint: false,
   src: './src/main.css'
 };
 
@@ -41,6 +44,7 @@ module.exports = function (gulp, options) {
   var name = opts.name;
   var prefix = opts.prefix;
   var plumb = opts.plumb;
+  var lint = opts.lint;
   // Don't prefix classes formatted as components, utilities or states.
   var prefixOpts = {
     ignore: [
@@ -58,6 +62,13 @@ module.exports = function (gulp, options) {
     plugins.push(
       prefixer(prefix, prefixOpts)
     )
+  }
+
+  if (lint) {
+    plugins.push(
+      stylelint(),
+      reporter({ clearMessages: true })
+    );
   }
 
   gulp.task(name, done => gulp.src(src)

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "lodash": "^3.10.1",
     "postcss-class-prefix": "^0.3.0",
     "postcss-import": "^7.0.0",
+    "postcss-reporter": "^2.0.0",
     "postcss-use": "^2.0.2",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.2.2",
+    "stylelint": "^7.6.0",
     "webpack": "^1.12.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds a `lint` option to the `css` task. When enabled, [stylelint](https://github.com/stylelint/stylelint) will report warnings/errors to the console (provided your project has a configuration file).

![screen shot 2016-11-22 at 2 32 05 pm](https://cloud.githubusercontent.com/assets/69633/20544792/86b648da-b0c0-11e6-9ac2-d853147615fe.png)

---

Closes #43 