### PR TITLE
Log webpack output

### DIFF
--- a/lib/js.js
+++ b/lib/js.js
@@ -1,9 +1,8 @@
 'use strict';
 
 var merge = require('lodash').merge;
-var utils = require('gulp-util');
+var gutil = require('gulp-util');
 var webpack = require('webpack');
-var PluginError = utils.PluginError;
 
 var defaults = {
   name: 'js',
@@ -17,7 +16,8 @@ var defaults = {
       },
       plugins: []
     }
-  }
+  },
+  logStatsOptions: 'minimal'
 };
 
 module.exports = function (gulp, options) {
@@ -35,7 +35,12 @@ module.exports = function (gulp, options) {
       );
     }
     webpack(settings, function (err, stats) {
-      if (err) throw new PluginError('webpack', err);
+      if (err) {
+        throw new gutil.PluginError('webpack', err);
+      }
+      
+      gutil.log('[' + gutil.colors.cyan('webpack') + ']', stats.toString(opts.logStatsOptions));
+      
       done();
     });
   });


### PR DESCRIPTION
This uses [webpack's recommendation](https://webpack.github.io/docs/usage-with-gulp.html#normal-compilation) for integrating logging into a Gulp workflow.

I decided to resolve this issue because Webpack's compilation errors are entirely silent otherwise. Multiple times this week I've been editing a JS file, thinking everything was going fine as my prototype was refreshing automatically, only to discover that at some point it had stopped _actually_ recompiling. Seems silly!

Example output when things go well:

<img width="676" alt="screen shot 2016-12-07 at 10 41 46 am" src="https://cloud.githubusercontent.com/assets/69633/20981491/cd7bbc96-bc69-11e6-91ce-4422a7866234.png">

And when things don't:

<img width="790" alt="screen shot 2016-12-07 at 10 43 41 am" src="https://cloud.githubusercontent.com/assets/69633/20981555/0eb5803e-bc6a-11e6-901c-493a4ff6fab8.png">

---

Fixes #34 