### PR TITLE
Tweak webpack logging

### DIFF
--- a/lib/js.js
+++ b/lib/js.js
@@ -17,7 +17,16 @@ var defaults = {
       plugins: []
     }
   },
-  logStatsOptions: 'minimal'
+  logStatsOptions: {
+    assets: true,
+    chunks: false,
+    chunkModules: false,
+    colors: true,
+    hash: false,
+    timings: false,
+    version: false,
+    modules: false
+  }
 };
 
 module.exports = function (gulp, options) {
@@ -39,7 +48,7 @@ module.exports = function (gulp, options) {
         throw new gutil.PluginError('webpack', err);
       }
       
-      gutil.log('[' + gutil.colors.cyan('webpack') + ']', stats.toString(opts.logStatsOptions));
+      gutil.log(gutil.colors.bold('webpack:'), '\n\n', stats.toString(opts.logStatsOptions), '\n');
       
       done();
     });


### PR DESCRIPTION
This tweaks the logging I added in #53 so that the default output is a bit more useful for humans.

The previous version looked nice until I realized it didn't actually break stuff onto new lines gracefully, and it was organized by "chunk," a noun I still don't fully understand. Basically, it was readable for exactly one file and kind of a mess afterward.

This version organizes the output by asset and takes into account line breaks.

<img width="664" alt="screen shot 2016-12-09 at 2 07 44 pm" src="https://cloud.githubusercontent.com/assets/69633/21066231/5cab6ad2-be19-11e6-8ebe-be7e6f99ac54.png">
