### PR TITLE
Add resolveFromFile option for postcss-use

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -50,7 +50,7 @@ module.exports = function(gulp, options) {
     ignore: [/^[^A-Zu-]/, /^(is|has)-/]
   };
   var src = opts.src;
-  var plugins = [importer(), use({ modules: '*' })];
+  var plugins = [importer(), use({ modules: '*', resolveFromFile: true })];
 
   if (prefix) {
     plugins.push(prefixer(prefix, prefixOpts));


### PR DESCRIPTION
This change lets plugins be resolved relative to the file where you `@use` them. I think this behavior makes a lot of sense, and I assumed it was the default for `postcss-use`, but apparently it is not.